### PR TITLE
Move elementor to a module

### DIFF
--- a/my-video-room/class-activation.php
+++ b/my-video-room/class-activation.php
@@ -45,6 +45,12 @@ class Activation {
 			Factory::get_instance( Modules::class )->activate_module( $room_builder_module );
 		}
 
+		$elementor_module = Factory::get_instance( Module::class )->get_module( 'elementor' );
+
+		if ( $elementor_module && $elementor_module->is_compatible() ) {
+			Factory::get_instance( Modules::class )->activate_module( $elementor_module );
+		}
+
 		return $this;
 	}
 

--- a/my-video-room/core/class-sitedefaults.php
+++ b/my-video-room/core/class-sitedefaults.php
@@ -163,17 +163,6 @@ class SiteDefaults extends Shortcode {
 	}
 
 	/**
-	 * Is_Elementor - checks if a Elementor is enabled.
-	 *
-	 * @return bool
-	 */
-	public function is_elementor_active() {
-		include_once ABSPATH . 'wp-admin/includes/plugin.php';
-
-		return ( is_plugin_active( 'elementor/elementor.php' ) );
-	}
-
-	/**
 	 * Generates all default Room Names for All Functions that use Video Rooms
 	 * Video functions call this function to get default room names to ensure all generate consistently
 	 *

--- a/my-video-room/module/elementor/class-module.php
+++ b/my-video-room/module/elementor/class-module.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * The entry point for the elementor plugin
+ *
+ * @package MyVideoRoomPlugin
+ */
+
+declare( strict_types=1 );
+
+namespace MyVideoRoomPlugin\Module\Elementor;
+
+/**
+ * Class Module
+ */
+class Module {
+
+	/**
+	 * Module constructor.
+	 */
+	public function __construct() {
+		\add_filter(
+			'myvideoroom_sitevideo_edit_actions',
+			function ( array $actions, int $post_id ) {
+				array_unshift(
+					$actions,
+					array(
+						'Edit in Elementor',
+						get_site_url() . '/wp-admin/post.php?post=' . esc_textarea( $post_id ) . '&action=elementor',
+						'fab fa-elementor',
+					)
+				);
+
+				return $actions;
+			},
+			10,
+			2
+		);
+	}
+}

--- a/my-video-room/module/elementor/index.php
+++ b/my-video-room/module/elementor/index.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * BuddyPress Module for MyVideoRoom
+ *
+ * @package MyVideoRoomPlugin/Module/BuddyPress
+ */
+
+declare( strict_types=1 );
+
+namespace MyVideoRoomPlugin\Module\Elementor;
+
+use MyVideoRoomPlugin\Library\Module;
+use MyVideoRoomPlugin\Module\Elementor\Module as Elementor;
+
+\add_action(
+	'myvideoroom_init',
+	function () {
+		Module::register(
+			'elementor',
+			'Elementor',
+			array(
+				sprintf(
+				/* translators: %s is a link to the Elementor website builder plugin */
+					\__(
+						'Adds functionality to integration MyVideoRoom and %s. Allows shortcode for editing generated pages in elementor',
+						'myvideoroom'
+					),
+					'<a href="https://elementor.com/">Elementor</a>'
+				),
+			),
+			fn() => new Elementor()
+		)->add_compatibility_hook(
+			function () {
+				include_once ABSPATH . 'wp-admin/includes/plugin.php';
+				return \is_plugin_active( 'elementor/elementor.php' );
+			}
+		);
+	}
+);

--- a/my-video-room/module/sitevideo/library/class-mvrsitevideodisplayrooms.php
+++ b/my-video-room/module/sitevideo/library/class-mvrsitevideodisplayrooms.php
@@ -69,12 +69,25 @@ class MVRSiteVideoDisplayRooms extends Shortcode {
 </td>
 <td class="mvr-table-height mvr-table-editpage">
 			<?php
+
+			$edit_actions = array(
+				array(
+					'Edit in WordPress',
+					get_site_url() . '/wp-admin/post.php?post=' . esc_textarea( $post_id ) . '&action=edit',
+					'dashicons dashicons-wordpress',
+				),
+			);
+
+			// Add any extra options.
+			$edit_actions = \apply_filters( 'myvideoroom_sitevideo_edit_actions', $edit_actions, $post_id );
+
+
 			// Render Buttons for Action Area.
 			if ( $post_id_return ) {
-				if ( Factory::get_instance( SiteDefaults::class )->is_elementor_active() ) {
-					echo '<a href="' . esc_url( get_site_url() ) . '/wp-admin/post.php?post=' . esc_textarea( $post_id ) . '&action=elementor" class="fab fa-elementor mvr-icons"target="_blank" title="Edit in Elementor"></a>';
+
+				foreach ( $edit_actions as $action ) {
+					echo '<a href="' . esc_url( $action[1] ) . '" class="mvr-icons ' . esc_attr( $action[2] ) . '" target="_blank" title="' . esc_attr( $action[0] ) . '"></a>';
 				}
-				echo '<a href="' . esc_url( get_site_url() ) . '/wp-admin/post.php?post=' . esc_textarea( $post_id ) . '&action=edit" class="dashicons mvr-icons dashicons-wordpress" target="_blank" title="Edit in WordPress"></a>';
 
 				//phpcs:ignore --WordPress.Security.NonceVerification.Recommended . Its a superglobal not user input.
 				if ( null !== ( esc_url_raw( wp_unslash( $_GET['page'] ) ) ) ){


### PR DESCRIPTION
@ccfredbaum  - optional PR - just as an idea.

I've move elementor into a module.

On plugin activation it will automatically detect if you have elementor installed, and if so then activate the module.

As you already have the plugin you will have to manually activate the module.

Feel free to reject if you don't like it!